### PR TITLE
avoid reallocation on balances init

### DIFF
--- a/database/state.go
+++ b/database/state.go
@@ -26,7 +26,7 @@ func NewStateFromDisk() (*State, error) {
 		return nil, err
 	}
 
-	balances := make(map[Account]uint)
+	balances := make(map[Account]uint, len(gen.Balances))
 	for account, balance := range gen.Balances {
 		balances[account] = balance
 	}


### PR DESCRIPTION
or an alternative would be to remove the whole block on line 29
```
balances := make(map[Account]uint)
for account, balance := range gen.Balances {
	balances[account] = balance
}
```
and just use genesis balances on line 41 like this
```
state := &State{gen.Balances, make([]Tx, 0), f}
```