### PR TITLE
Checking for sufficient balance when applying a transaction.

### DIFF
--- a/database/state.go
+++ b/database/state.go
@@ -96,7 +96,7 @@ func (s *State) apply(tx Tx) error {
 		return nil
 	}
 
-	if s.Balances[tx.From] - tx.Value < 0 {
+	if s.Balances[tx.From] < tx.Value {
 		return fmt.Errorf("insufficient balance")
 	}
 


### PR DESCRIPTION
When substracting the transaction's value (uint) to the sender's balance (uint) the result is also uint and the resulting value never less than 0. This allowed to make transactions from accounts without sufficient balance or previously non-existent.