### PR TITLE
Add Account/Version to Peer Status, Fix Miner

### DIFF
--- a/cmd/tbb/run.go
+++ b/cmd/tbb/run.go
@@ -18,10 +18,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/web3coach/the-blockchain-bar/database"
 	"github.com/web3coach/the-blockchain-bar/node"
-	"os"
 )
 
 func runCmd() *cobra.Command {
@@ -46,13 +47,15 @@ func runCmd() *cobra.Command {
 				true,
 				database.NewAccount(bootstrapAcc),
 				false,
+				"",
 			)
 
 			if !isSSLDisabled {
 				port = node.HttpSSLPort
 			}
 
-			n := node.New(getDataDirFromCmd(cmd), ip, port, database.NewAccount(miner), bootstrap)
+			version := fmt.Sprintf("%s.%s.%s-alpha %s %s", Major, Minor, Fix, shortGitCommit(GitCommit), Verbal)
+			n := node.New(getDataDirFromCmd(cmd), ip, port, database.NewAccount(miner), bootstrap, version)
 			err := n.Run(context.Background(), isSSLDisabled, sslEmail)
 			if err != nil {
 				fmt.Println(err)

--- a/node/http_routes.go
+++ b/node/http_routes.go
@@ -52,6 +52,7 @@ type StatusRes struct {
 	KnownPeers  map[string]PeerNode `json:"peers_known"`
 	PendingTXs  []database.SignedTx `json:"pending_txs"`
 	NodeVersion string              `json:"node_version"`
+	Account     common.Address      `json:"account"`
 }
 
 type SyncRes struct {
@@ -116,6 +117,7 @@ func statusHandler(w http.ResponseWriter, r *http.Request, node *Node) {
 		KnownPeers:  node.knownPeers,
 		PendingTXs:  node.getPendingTXsAsArray(),
 		NodeVersion: node.nodeVersion,
+		Account:     database.NewAccount(node.info.Account.String()),
 	}
 
 	writeRes(w, res)

--- a/node/node_integration_test.go
+++ b/node/node_integration_test.go
@@ -49,6 +49,7 @@ const testKsBabaYagaAccount = "0x6fdc0d8d15ae6b4ebf45c52fd2aafbcbb19a65c8"
 const testKsAndrejFile = "test_andrej--3eb92807f1f91a8d4d85bc908c7f86dcddb1df57"
 const testKsBabaYagaFile = "test_babayaga--6fdc0d8d15ae6b4ebf45c52fd2aafbcbb19a65c8"
 const testKsAccountsPwd = "security123"
+const nodeVersion = "0.0.0-alpha 01abcd Test Run"
 
 func TestNode_Run(t *testing.T) {
 	datadir, err := getTestDataDirPath()
@@ -60,7 +61,7 @@ func TestNode_Run(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	n := New(datadir, "127.0.0.1", 8085, database.NewAccount(DefaultMiner), PeerNode{})
+	n := New(datadir, "127.0.0.1", 8085, database.NewAccount(DefaultMiner), PeerNode{}, nodeVersion)
 
 	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
 	err = n.Run(ctx, true, "")
@@ -84,11 +85,12 @@ func TestNode_Mining(t *testing.T) {
 		false,
 		babaYaga,
 		true,
+		nodeVersion,
 	)
 
 	// Construct a new Node instance and configure
 	// Andrej as a miner
-	n := New(dataDir, nInfo.IP, nInfo.Port, andrej, nInfo)
+	n := New(dataDir, nInfo.IP, nInfo.Port, andrej, nInfo, nodeVersion)
 
 	// Allow the mining to run for 30 mins, in the worst case
 	ctx, closeNode := context.WithTimeout(
@@ -185,9 +187,9 @@ func TestNode_ForgedTx(t *testing.T) {
 	}
 	defer fs.RemoveDir(dataDir)
 
-	n := New(dataDir, "127.0.0.1", 8085, andrej, PeerNode{})
+	n := New(dataDir, "127.0.0.1", 8085, andrej, PeerNode{}, nodeVersion)
 	ctx, closeNode := context.WithTimeout(context.Background(), time.Minute*30)
-	andrejPeerNode := NewPeerNode("127.0.0.1", 8085, false, andrej, true)
+	andrejPeerNode := NewPeerNode("127.0.0.1", 8085, false, andrej, true, nodeVersion)
 
 	txValue := uint(5)
 	txNonce := uint(1)
@@ -273,10 +275,10 @@ func TestNode_ReplayedTx(t *testing.T) {
 	}
 	defer fs.RemoveDir(dataDir)
 
-	n := New(dataDir, "127.0.0.1", 8085, andrej, PeerNode{})
+	n := New(dataDir, "127.0.0.1", 8085, andrej, PeerNode{}, nodeVersion)
 	ctx, closeNode := context.WithCancel(context.Background())
-	andrejPeerNode := NewPeerNode("127.0.0.1", 8085, false, andrej, true)
-	babaYagaPeerNode := NewPeerNode("127.0.0.1", 8086, false, babaYaga, true)
+	andrejPeerNode := NewPeerNode("127.0.0.1", 8085, false, andrej, true, nodeVersion)
+	babaYagaPeerNode := NewPeerNode("127.0.0.1", 8086, false, babaYaga, true, nodeVersion)
 
 	txValue := uint(5)
 	txNonce := uint(1)
@@ -396,9 +398,10 @@ func TestNode_MiningStopsOnNewSyncedBlock(t *testing.T) {
 		false,
 		database.NewAccount(""),
 		true,
+		nodeVersion,
 	)
 
-	n := New(dataDir, nInfo.IP, nInfo.Port, babaYaga, nInfo)
+	n := New(dataDir, nInfo.IP, nInfo.Port, babaYaga, nInfo, nodeVersion)
 
 	// Allow the test to run for 30 mins, in the worst case
 	ctx, closeNode := context.WithTimeout(context.Background(), time.Minute*30)
@@ -561,9 +564,9 @@ func TestNode_MiningSpamTransactions(t *testing.T) {
 	}
 	defer fs.RemoveDir(dataDir)
 
-	n := New(dataDir, "127.0.0.1", 8085, miner, PeerNode{})
+	n := New(dataDir, "127.0.0.1", 8085, miner, PeerNode{}, nodeVersion)
 	ctx, closeNode := context.WithCancel(context.Background())
-	minerPeerNode := NewPeerNode("127.0.0.1", 8085, false, miner, true)
+	minerPeerNode := NewPeerNode("127.0.0.1", 8085, false, miner, true, nodeVersion)
 
 	txValue := uint(200)
 	txCount := uint(4)

--- a/node/sync.go
+++ b/node/sync.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/web3coach/the-blockchain-bar/database"
@@ -158,7 +159,7 @@ func (n *Node) joinKnownPeers(peer PeerNode) error {
 		return nil
 	}
 
-	url := fmt.Sprintf(
+	p_url := fmt.Sprintf(
 		"%s://%s%s?%s=%s&%s=%d&%s=%s&%s=%s",
 		peer.ApiProtocol(),
 		peer.TcpAddress(),
@@ -168,12 +169,12 @@ func (n *Node) joinKnownPeers(peer PeerNode) error {
 		endpointAddPeerQueryKeyPort,
 		n.info.Port,
 		endpointAddPeerQueryKeyMiner,
-		n.info.Account,
+		n.info.Account.String(),
 		endpointAddPeerQueryKeyVersion,
-		n.nodeVersion,
+		url.QueryEscape(n.info.NodeVersion),
 	)
 
-	res, err := http.Get(url)
+	res, err := http.Get(p_url)
 	if err != nil {
 		return err
 	}

--- a/node/sync.go
+++ b/node/sync.go
@@ -18,9 +18,10 @@ package node
 import (
 	"context"
 	"fmt"
-	"github.com/web3coach/the-blockchain-bar/database"
 	"net/http"
 	"time"
+
+	"github.com/web3coach/the-blockchain-bar/database"
 )
 
 func (n *Node) sync(ctx context.Context) error {
@@ -158,7 +159,7 @@ func (n *Node) joinKnownPeers(peer PeerNode) error {
 	}
 
 	url := fmt.Sprintf(
-		"%s://%s%s?%s=%s&%s=%d",
+		"%s://%s%s?%s=%s&%s=%d&%s=%s&%s=%s",
 		peer.ApiProtocol(),
 		peer.TcpAddress(),
 		endpointAddPeer,
@@ -166,6 +167,10 @@ func (n *Node) joinKnownPeers(peer PeerNode) error {
 		n.info.IP,
 		endpointAddPeerQueryKeyPort,
 		n.info.Port,
+		endpointAddPeerQueryKeyMiner,
+		n.info.Account,
+		endpointAddPeerQueryKeyVersion,
+		n.nodeVersion,
 	)
 
 	res, err := http.Get(url)


### PR DESCRIPTION
In the output below you will see for the node itself a key of 'node_version' and 'account' have been added.  Similarly under the 'peers_known' list, 'account' has been made to display correctly, and a 'node_version' has been added.  You can see here that some of the peer data came from the bootstrap node, and as such doesn't contain the 'node_version' data.

curl -Ls -X GET http://73.94.107.106:8995/node/status | jq .

```json
{
  "block_hash": "0000007414e771708a2f5e2cdd16e29dd2b2a5a858bbb5341a4eb8d855fc8861",
  "block_number": 19,
  "peers_known": {
    "73.94.107.106:8996": {
      "ip": "73.94.107.106",
      "port": 8996,
      "is_bootstrap": false,
      "account": "0xf04679700642fd1455782e1acc37c314aab1a847",
      "node_version": "1.3.1-alpha  TX Gas"
    },
    "73.94.107.106:8997": {
      "ip": "73.94.107.106",
      "port": 8997,
      "is_bootstrap": false,
      "account": "0xdd1fbd71d7f78a810ae10829220fbb7bd2f1818b",
      "node_version": ""
    },
    "node.tbb.web3.coach:443": {
      "ip": "node.tbb.web3.coach",
      "port": 443,
      "is_bootstrap": true,
      "account": "0x09ee50f2f37fcba1845de6fe5c762e83e65e755c",
      "node_version": ""
    }
  },
  "pending_txs": [],
  "node_version": "1.3.1-alpha  TX Gas",
  "account": "0xdd1fbd71d7f78a810ae10829220fbb7bd2f1818b"
}
```